### PR TITLE
Include the bats file with the test script

### DIFF
--- a/recipes/scanpy-scripts/build.sh
+++ b/recipes/scanpy-scripts/build.sh
@@ -3,3 +3,4 @@
 mkdir -p $PREFIX/bin
 cp *.py $PREFIX/bin
 cp *.sh $PREFIX/bin
+cp *.bats $PREFIX/bin


### PR DESCRIPTION
@nh3 - the post-install test script doesn't currently work with the Conda install of scanpy-scripts. This is partly due to the .bats file not being copied (remedied here), and partly because of the './' call for from the .sh (should just assume the bats is available in the PATH). 