### PR TITLE
Add recipe for atlas-fastq-provider

### DIFF
--- a/recipes/atlas-fastq-provider/build.sh
+++ b/recipes/atlas-fastq-provider/build.sh
@@ -1,0 +1,8 @@
+mkdir -p $PREFIX/bin
+cp *.sh $PREFIX/bin
+
+# Create a config if not already present
+
+if [ ! -e $PREFIX/bin/atlas-fastq-provider-config.sh ]; then
+    cp atlas-fastq-provider-config.sh.default $PREFIX/bin/atlas-fastq-provider-config.sh
+fi

--- a/recipes/atlas-fastq-provider/meta.yaml
+++ b/recipes/atlas-fastq-provider/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.0" %}
+{% set version = "0.4.1" %}
 
 package:
   name: atlas-fastq-provider
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/atlas-fastq-provider/archive/v{{ version }}.tar.gz
-  sha256: 9e6b794d7dddf2c24d4d0a048d0dc842db05f73e90a570769934478cd982ae2b
+  sha256: e4a571ee4000c2ef187fc4c3d0fe475bcbce7dde4205f3398020fabc098d805c
 
 build:
   number: 0

--- a/recipes/atlas-fastq-provider/meta.yaml
+++ b/recipes/atlas-fastq-provider/meta.yaml
@@ -1,0 +1,30 @@
+{% set version = "0.4.0" %}
+
+package:
+  name: atlas-fastq-provider
+  version: {{ version }}
+
+source:
+  url: https://github.com/ebi-gene-expression-group/atlas-fastq-provider/archive/v{{ version }}.tar.gz
+  sha256: 9e6b794d7dddf2c24d4d0a048d0dc842db05f73e90a570769934478cd982ae2b
+
+build:
+  number: 1
+
+requirements:
+  build:
+  host:
+  run:
+    - bash
+    - wget
+    - coreutils 
+
+test:
+  commands:
+    - fetchFastq.sh -h
+
+about:
+  home: https://github.com/ebi-gene-expression-group/atlas-fastq-provider
+  license: GPL-3
+  summary: A package to provide FASTQs via download or file system linking
+  license_family: GPL3

--- a/recipes/atlas-fastq-provider/meta.yaml
+++ b/recipes/atlas-fastq-provider/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9e6b794d7dddf2c24d4d0a048d0dc842db05f73e90a570769934478cd982ae2b
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Add recipe for [atlas-fastq-provider](https://github.com/ebi-gene-expression-group/atlas-fastq-provider) to Bioconda